### PR TITLE
Define "_POSIX_C_SOURCE" before

### DIFF
--- a/cbitstruct/_cbitstruct.c
+++ b/cbitstruct/_cbitstruct.c
@@ -1,11 +1,10 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-
-#define PY_SSIZE_T_CLEAN
-
-#include <Python.h>
 
 #define BIT_MASK(__TYPE__, __ONE_COUNT__)  \
     (((__TYPE__)(-((__ONE_COUNT__) != 0))) \

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="cbitstruct",
-    version="1.0.3",
+    version="1.0.4",
     author="Quentin CHATEAU",
     author_email="quentin.chateau@gmail.com",
     license="GPLv3",


### PR DESCRIPTION
"limits.h" will define "_POSIX_C_SOURCE" to a sensible value if it
is not defined when it is included. Including "Python.h" will
always define it, so it should be included first.