### PR TITLE
Fix memory leak from unreleased buffers in pack_into

### DIFF
--- a/cbitstruct/_cbitstruct.c
+++ b/cbitstruct/_cbitstruct.c
@@ -1413,6 +1413,9 @@ static PyObject* pack_into(PyObject* module, PyObject* args, PyObject* kwargs)
 
 exit:
     CompiledFormat_deinit(&self);
+    if (buffer.obj) {
+        PyBuffer_Release(&buffer);
+    }
     return return_value;
 }
 

--- a/cbitstruct/tests/test_bitstruct.py
+++ b/cbitstruct/tests/test_bitstruct.py
@@ -460,6 +460,9 @@ class BitstructTest(unittest.TestCase):
             packed = bytearray(b'\x00')
             pack_into('b1t24', packed, 0, False)
 
+        # Ensure buffer was released correctly
+        packed.extend(b'extendable')
+
     def test_unpack_from(self):
         """Unpack values at given bit offset.
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="cbitstruct",
-    version="1.1.1",
+    version="1.1.2",
     author="Quentin CHATEAU",
     author_email="quentin.chateau@gmail.com",
     license="MPL-2.0",


### PR DESCRIPTION
The `pack_into` implementation was missing a buffer release unlike the it's complied format counterpart. This causes a small memory leak, which correctly releasing the buffer fixes.

The test update also highlight that with the unreleased buffer, there will be existing exports of the buffer which restrict its mutability. Without this change attempting to do any resizing mutation on a buffer after calling `pack_into` would result in a `BufferError`. 